### PR TITLE
v1.0.8

### DIFF
--- a/CoffeeToolkit.Tests/CoffeeToolkit.Tests.csproj
+++ b/CoffeeToolkit.Tests/CoffeeToolkit.Tests.csproj
@@ -7,10 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0-release-20210626-04" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/CoffeeToolkit.Tests/Database/DatabaseUpgraderTests.cs
+++ b/CoffeeToolkit.Tests/Database/DatabaseUpgraderTests.cs
@@ -1,30 +1,27 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data.Common;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using CoffeeToolkit.Database;
 using CoffeeToolkit.Tests.TestHelpers;
-using NUnit.Framework;
+using Xunit;
 
 namespace CoffeeToolkit.Tests.Database
 {
-    class DatabaseUpgraderTests
+    public class DatabaseUpgraderTests
     {
-        [Test]
-        [TestCase(null)]
-        [TestCase("CoffeeToolkit.Tests.TestHelpers")]
+        [Theory]
+        [InlineData(null)]
+        [InlineData("CoffeeToolkit.Tests.TestHelpers")]
         public void GetAllMigrations_ExpectDuplicateException(string namespaceBase)
         {
             DatabaseUpgrader<DbConnection> databaseUpgrader =
                 new(MigrationHelpers.GetEmptyDbConnection());
-            Assert.Throws<ArgumentException>(() => databaseUpgrader.GetAllMigrations());
+            Assert.Throws<ArgumentException>(() => databaseUpgrader.GetAllMigrations(namespaceBase));
         }
 
-        [Test]
-        [TestCase("CoffeeToolkit.Tests.TestHelpers.MigratationsOne")]
-        [TestCase("CoffeeToolkit.Tests.TestHelpers.MigratationsTwo")]
+        [Theory]
+        [InlineData("CoffeeToolkit.Tests.TestHelpers.MigratationsOne")]
+        [InlineData("CoffeeToolkit.Tests.TestHelpers.MigratationsTwo")]
         public void GetAllMigrations_ExpectCorrespondingQuery(
             string namespaceBase)
         {
@@ -32,10 +29,10 @@ namespace CoffeeToolkit.Tests.Database
                 new(MigrationHelpers.GetEmptyDbConnection());
 
             List<IMigration> migrations = databaseUpgrader.GetAllMigrations(namespaceBase);
-            Assert.AreEqual(
+            Assert.Equal(
                 $"SELECT {migrations[0].DbVersion};", 
                 migrations[0].MigrationSql);
-            Assert.AreEqual(
+            Assert.Equal(
                 $"SELECT {migrations[1].DbVersion};",
                 migrations[1].MigrationSql);
         }

--- a/CoffeeToolkit.Tests/Linq/LinqExtensionTests.cs
+++ b/CoffeeToolkit.Tests/Linq/LinqExtensionTests.cs
@@ -1,0 +1,36 @@
+﻿using CoffeeToolkit.Linq;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace CoffeeToolkit.Tests.Linq
+{
+    public class LinqExtensionTests
+    {
+        [Fact]
+        public void DefaultOrNull_Defaultable_ExpectNull()
+        {
+            // List of value type, which returns not null as default()
+            List<KeyValuePair<string, string>> emptyDefaultableList = new();
+            Assert.Null(emptyDefaultableList.FirstOrNull());
+        }
+
+        [Fact]
+        public void DefaultOrNull_FilteredValueType_ExpectFirstValue()
+        {
+            // List of value type, which returns not null as default()
+            List<KeyValuePair<string, string>> emptyDefaultableList = new()
+            {
+                new("firstkey", "firstvalue"),
+                new("secondkey", "secondvalue"),
+            };
+
+            // Run through linq query, get nullable value as result
+            KeyValuePair<string, string>? result = emptyDefaultableList
+                .Where(x => true == true) // select all
+                .FirstOrNull();
+
+            Assert.Equal("firstkey", result.Value.Key);
+        }
+    }
+}

--- a/CoffeeToolkit.Tests/Progress/ProgressTrackerTests.cs
+++ b/CoffeeToolkit.Tests/Progress/ProgressTrackerTests.cs
@@ -1,16 +1,13 @@
 ﻿using CoffeeToolkit.Progress;
-using NUnit.Framework;
+using Xunit;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 
 namespace CoffeeToolkit.Tests.Progress
 {
-    class ProgressTrackerTests
+    public class ProgressTrackerTests
     {
-        [Test]
+        [Fact]
         public void IncrementProgress_IncrementFirst_ValidateIncrementAndTimeEstimate()
         {
             // Increment pt 10 times with delay
@@ -22,16 +19,16 @@ namespace CoffeeToolkit.Tests.Progress
             }
 
             // Validate increment
-            Assert.AreEqual(10, pt.ProcessedItems);
-            Assert.AreNotEqual(DateTime.MinValue, pt.StartTime);
+            Assert.Equal(10, pt.ProcessedItems);
+            Assert.NotEqual(DateTime.MinValue, pt.StartTime);
 
             // Validate time estimate
             var estMs = pt.GetEstimatedRemainingTime().TotalMilliseconds;
-            Assert.GreaterOrEqual(estMs, 1000);
-            Assert.LessOrEqual(estMs, 1500);
+            Assert.True(estMs >= 1000);
+            Assert.True(estMs <= 1500);
         }
 
-        [Test]
+        [Fact]
         public void ProgressEvent_IncrementTwo_ValidateEventsFired()
         {
             ProgressTracker pt = new ProgressTracker(2);
@@ -41,21 +38,21 @@ namespace CoffeeToolkit.Tests.Progress
                 eventFiredCount++;
                 if (eventFiredCount == 1)
                 {
-                    Assert.AreEqual(1, e.ItemsProcessed);
+                    Assert.Equal(1, e.ItemsProcessed);
                 }
                 else if (eventFiredCount == 2)
                 {
-                    Assert.AreEqual(0, e.TimeRemaining.TotalMilliseconds);
-                    Assert.AreEqual(100, e.ProgressPercentage);
+                    Assert.Equal(0, e.TimeRemaining.TotalMilliseconds);
+                    Assert.Equal(100, e.ProgressPercentage);
                 }
             };
             pt.IncrementProgress();
             pt.IncrementProgress();
 
-            Assert.AreEqual(2, eventFiredCount);
+            Assert.Equal(2, eventFiredCount);
         }
 
-        [Test]
+        [Fact]
         public void ProgressEvent_IncremenOne_ValidatePercentage()
         {
             ProgressTracker pt = new ProgressTracker(200);
@@ -64,11 +61,11 @@ namespace CoffeeToolkit.Tests.Progress
             {
                 eventFiredCount++;
                 if (eventFiredCount == 1)
-                    Assert.AreEqual(0.5, e.ProgressPercentage);
+                    Assert.Equal(0.5, e.ProgressPercentage);
             };
             pt.IncrementProgress();
 
-            Assert.AreEqual(1, eventFiredCount);
+            Assert.Equal(1, eventFiredCount);
         }
     }
 }

--- a/CoffeeToolkit.Tests/Random/RngTests.cs
+++ b/CoffeeToolkit.Tests/Random/RngTests.cs
@@ -1,37 +1,34 @@
 ﻿using CoffeeToolkit.Random;
-using NUnit.Framework;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Xunit;
 
 namespace CoffeeToolkit.Tests.Random
 {
-    class RngTests
+    public class RngTests
     {
-        [Test]
-        [TestCase(0,1)]
-        [TestCase(-2, -1)]
-        [TestCase(-1, 0)]
-        [TestCase(-1000, 0)]
-        [TestCase(-1000, 1000)]
+        [Theory]
+        [InlineData(0, 1)]
+        [InlineData(-2, -1)]
+        [InlineData(-1, 0)]
+        [InlineData(-1000, 0)]
+        [InlineData(-1000, 1000)]
         public void Generate_ManyAttempts_InRangeNoException(int min, int max)
         {
             int number = 0;
             for (int i = 0; i < 1000; i++)
             {
                 number = Rng.Generate(min, max);
-                Assert.GreaterOrEqual(number, min);
-                Assert.LessOrEqual(number, max);
+                Assert.True(number >= min);
+                Assert.True(number <= max);
             }
         }
 
-        [Test]
-        [TestCase(0, 1)]
-        [TestCase(-1, 0)]
-        [TestCase(-1000, 0)]
-        [TestCase(-1000, 1000)]
+        [Theory]
+        [InlineData(0, 1)]
+        [InlineData(-1, 0)]
+        [InlineData(-1000, 0)]
+        [InlineData(-1000, 1000)]
         public void Generate_ManyAttempts_NotSpammingSameResult(int min, int max)
         {
             Dictionary<int, int> results = new();
@@ -50,10 +47,10 @@ namespace CoffeeToolkit.Tests.Random
             int mostHitsCount = results
                 .OrderByDescending(x => x.Value)
                 .First().Value;
-            Assert.Less(mostHitsCount, 900);
+            Assert.True(mostHitsCount < 900);
         }
 
-        [Test]
+        [Fact]
         public void Types_TryAll_NoException()
         {
             bool a = Rng.Bool();
@@ -69,16 +66,16 @@ namespace CoffeeToolkit.Tests.Random
             byte[] k = Rng.ByteArray(16);
         }
 
-        [Test]
+        [Fact]
         public void Generate_AllInt32Variants_NotZeroNoException()
         {
             int noArgs = Rng.Generate();
             int oneArg = Rng.Generate(int.MaxValue);
             int TwoArgs = Rng.Generate(1, int.MaxValue);
 
-            Assert.NotZero(noArgs); // Fails 1 in int.MaxValue) times
-            Assert.NotZero(oneArg); // Fails 1 in int.MaxValue) times
-            Assert.NotZero(TwoArgs);
+            Assert.NotEqual(0, noArgs); // Fails 1 in int.MaxValue) times
+            Assert.NotEqual(0, oneArg); // Fails 1 in int.MaxValue) times
+            Assert.NotEqual(0, TwoArgs);
         }
     }
 }

--- a/CoffeeToolkit.Tests/Time/DateTimeRounderTests.cs
+++ b/CoffeeToolkit.Tests/Time/DateTimeRounderTests.cs
@@ -1,17 +1,13 @@
 ﻿using CoffeeToolkit.Extensions;
 using CoffeeToolkit.Time;
-using NUnit.Framework;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Xunit;
 
 namespace CoffeeToolkit.Tests.Time
 {
-    class DateTimeRounderTests
+    public class DateTimeRounderTests
     {
-        [Test]
+        [Fact]
         public void DateTimeRounderExtensionMethods_ValidResults()
         {
             // Prepare data
@@ -22,44 +18,44 @@ namespace CoffeeToolkit.Tests.Time
             DateTime expectHigh = DateTime.Parse("2020-01-01 1:00:00");
 
             // Run tests
-            Assert.AreEqual(expectLow, actualLow.RoundDown(increment));
-            Assert.AreEqual(expectLow, actualHigh.RoundDown(increment));
-            Assert.AreEqual(expectHigh, actualHigh.RoundUp(increment));
-            Assert.AreEqual(expectHigh, actualLow.RoundUp(increment));
-            Assert.AreEqual(expectLow, actualLow.RoundToNearest(increment));
-            Assert.AreEqual(expectHigh, actualHigh.RoundToNearest(increment));
+            Assert.Equal(expectLow, actualLow.RoundDown(increment));
+            Assert.Equal(expectLow, actualHigh.RoundDown(increment));
+            Assert.Equal(expectHigh, actualHigh.RoundUp(increment));
+            Assert.Equal(expectHigh, actualLow.RoundUp(increment));
+            Assert.Equal(expectLow, actualLow.RoundToNearest(increment));
+            Assert.Equal(expectHigh, actualHigh.RoundToNearest(increment));
         }
 
-        [Test]
-        [TestCase("2020-01-01 0:00:00", "2020-01-01 0:00:00", Description = "RoundDown to same value")]
-        [TestCase("2020-01-01 0:07:00", "2020-01-01 0:00:00", Description = "RoundDown to lower value")]
-        [TestCase("2020-01-01 0:57:00", "2020-01-01 0:00:00", Description = "RoundDown to lower value from high")]
+        [Theory]
+        [InlineData("2020-01-01 0:00:00", "2020-01-01 0:00:00")] // RoundDown to same value
+        [InlineData("2020-01-01 0:07:00", "2020-01-01 0:00:00")] // RoundDown to lower value
+        [InlineData("2020-01-01 0:57:00", "2020-01-01 0:00:00")] // RoundDown to lower value from high
         public void RoundDown_TestResults(string inputDtStr, string expectedDtStr)
         {
             DateTime input = DateTime.Parse(inputDtStr);
             DateTime actual = DateTimeRounder.RoundDown(input, TimeSpan.FromHours(1));
-            Assert.AreEqual(DateTime.Parse(expectedDtStr), actual);
+            Assert.Equal(DateTime.Parse(expectedDtStr), actual);
         }
 
-        [Test]
-        [TestCase("2020-01-01 0:00:00", "2020-01-01 0:00:00", Description = "RoundUp to same value")]
-        [TestCase("2020-01-01 0:07:00", "2020-01-01 1:00:00", Description = "RoundUp to higher value from low")]
-        [TestCase("2020-01-01 0:57:00", "2020-01-01 1:00:00", Description = "RoundDown to higher value")]
+        [Theory]
+        [InlineData("2020-01-01 0:00:00", "2020-01-01 0:00:00")] // RoundUp to same value
+        [InlineData("2020-01-01 0:07:00", "2020-01-01 1:00:00")] // RoundUp to higher value from low
+        [InlineData("2020-01-01 0:57:00", "2020-01-01 1:00:00")] // RoundDown to higher value
         public void RoundUp_TestResults(string inputDtStr, string expectedDtStr)
         {
             DateTime input = DateTime.Parse(inputDtStr);
             DateTime actual = DateTimeRounder.RoundUp(input, TimeSpan.FromHours(1));
-            Assert.AreEqual(DateTime.Parse(expectedDtStr), actual);
+            Assert.Equal(DateTime.Parse(expectedDtStr), actual);
         }
 
-        [Test]
-        [TestCase("2020-01-01 0:51:00", "2020-01-01 1:00:00", Description = "Expect RoundUp from high")]
-        [TestCase("2020-01-01 0:11:00", "2020-01-01 0:00:00", Description = "Expect RoundDown from low")]
+        [Theory]
+        [InlineData("2020-01-01 0:51:00", "2020-01-01 1:00:00")] // Expect RoundUp from high
+        [InlineData("2020-01-01 0:11:00", "2020-01-01 0:00:00")] // Expect RoundDown from low
         public void RoundToNearest_TestResults(string inputDtStr, string expectedDtStr)
         {
             DateTime input = DateTime.Parse(inputDtStr);
             DateTime actual = DateTimeRounder.RoundToNearest(input, TimeSpan.FromHours(1));
-            Assert.AreEqual(DateTime.Parse(expectedDtStr), actual);
+            Assert.Equal(DateTime.Parse(expectedDtStr), actual);
         }
     }
 }

--- a/CoffeeToolkit.Tests/Time/DateTimeRounderTests.cs
+++ b/CoffeeToolkit.Tests/Time/DateTimeRounderTests.cs
@@ -1,5 +1,4 @@
-﻿using CoffeeToolkit.Extensions;
-using CoffeeToolkit.Time;
+﻿using CoffeeToolkit.Time;
 using System;
 using Xunit;
 

--- a/CoffeeToolkit.Tests/Time/UnixTimeTests.cs
+++ b/CoffeeToolkit.Tests/Time/UnixTimeTests.cs
@@ -1,5 +1,4 @@
-﻿using CoffeeToolkit.Extensions;
-using CoffeeToolkit.Time;
+﻿using CoffeeToolkit.Time;
 using System;
 using Xunit;
 

--- a/CoffeeToolkit.Tests/Time/UnixTimeTests.cs
+++ b/CoffeeToolkit.Tests/Time/UnixTimeTests.cs
@@ -1,58 +1,49 @@
 ﻿using CoffeeToolkit.Extensions;
 using CoffeeToolkit.Time;
-using NUnit.Framework;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Xunit;
 
 namespace CoffeeToolkit.Tests.Time
 {
-    class UnixTimeTests
+    public class UnixTimeTests
     {
-        [Test]
-        [TestCase("2020-01-01 0:00:00", 1577836800)]
-        [TestCase("2020-01-01 0:00:00.999", 1577836800, Description = "Expect floor")]
-        [TestCase("1969-01-01 0:00:00", -31536000, Description = "Expect negative")]
+        [Theory]
+        [InlineData("2020-01-01 0:00:00", 1577836800)]
+        [InlineData("2020-01-01 0:00:00.999", 1577836800)] // Expect floor
+        [InlineData("1969-01-01 0:00:00", -31536000)] // Expect negative
         public void FromDateTime_TestResults(string dtStr, int expected)
         {
             DateTime input = DateTime.Parse(dtStr);
             int actual = UnixTime.FromDateTime(input);
-            Assert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
 
-        [Test(Description = "Expect OutOfRangeException for compatability")]
-        [TestCase("2040-01-01 0:00:00", Description = "Too high")]
-        [TestCase("1900-01-01 0:00:00", Description = "Too low")]
+        [Theory]
+        [InlineData("2040-01-01 0:00:00")] // Too high
+        [InlineData("1900-01-01 0:00:00")] //Too low
         public void FromDateTime_OutOfRange_ExpectException(string dtStr)
         {
             DateTime input = DateTime.Parse(dtStr);
-            try
-            {
-                int result = UnixTime.FromDateTime(input);
-                Assert.Fail("Result type should be int to maintain compatability. Create another method.");
-            }
-            catch (ArgumentOutOfRangeException) { Assert.Pass(); };
+            Assert.Throws<ArgumentOutOfRangeException>(() => UnixTime.FromDateTime(input));
         }
 
-        [Test]
-        [TestCase("2020-01-01 0:00:00", 1577836800)]
-        [TestCase("1969-01-01 0:00:00", -31536000, Description = "With negative")]
+        [Theory]
+        [InlineData("2020-01-01 0:00:00", 1577836800)]
+        [InlineData("1969-01-01 0:00:00", -31536000)] // With negative
         public void ToDateTime_TestResults(string dtStr, int input)
         {
             DateTime expected = DateTime.Parse(dtStr);
             DateTime actual = UnixTime.ToDateTime(input);
-            Assert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
 
-        [Test]
-        [TestCase("2020-01-01 0:00:00", 1577836800)]
+        [Theory]
+        [InlineData("2020-01-01 0:00:00", 1577836800)]
         public void ToUnixTime_ExtensionMethod(string dtStr, int expected)
         {
             DateTime input = DateTime.Parse(dtStr);
             int actual = input.ToUnixTime();
-            Assert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/CoffeeToolkit/CoffeeToolkit.csproj
+++ b/CoffeeToolkit/CoffeeToolkit.csproj
@@ -6,11 +6,11 @@
     <Authors>NotCoffee418</Authors>
     <PackageProjectUrl>https://github.com/NotCoffee418/CoffeeToolkit</PackageProjectUrl>
     <RepositoryUrl>https://github.com/NotCoffee418/CoffeeToolkit</RepositoryUrl>
-    <Version>1.0.7</Version>
+    <Version>1.0.8</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Commonly used functions and classes I would otherwise keep rewriting.</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReleaseNotes>DatabaseUpgrader bug fixes</PackageReleaseNotes>
+    <PackageReleaseNotes>Add FirstOrNull()</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CoffeeToolkit/Linq/LinqExtensions.cs
+++ b/CoffeeToolkit/Linq/LinqExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace CoffeeToolkit.Linq
+{
+    public static class LinqExtensions
+    {
+        /// <summary>
+        /// Returns the first element of sequence, or null if the sequence contains no elements
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="items"></param>
+        /// <returns></returns>
+        public static T? FirstOrNull<T>(this IEnumerable<T> items) where T : struct
+        {
+            var iter = items.GetEnumerator();
+            if (!iter.MoveNext())
+                return (T?)null;
+
+            return iter.Current;
+        }
+    }
+}

--- a/CoffeeToolkit/Time/DateTimeExtensions.cs
+++ b/CoffeeToolkit/Time/DateTimeExtensions.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace CoffeeToolkit.Extensions
+namespace CoffeeToolkit.Time
 {
     public static class DateTimeExtensions
     {


### PR DESCRIPTION
- Added Linq extension FirstOrNull()
- Removed the CoffeeToolkit.Extensions namespace (BREAKING!!) 
- UnixTime extensions now located in CoffeeTookit.Time
- Unit tests now use xUnit