### PR TITLE
BREAKING CHANGE: UnixTime methods standardized 

### DIFF
--- a/CoffeeToolkit.Tests/Time/DateTimeRounderTests.cs
+++ b/CoffeeToolkit.Tests/Time/DateTimeRounderTests.cs
@@ -57,20 +57,26 @@ namespace CoffeeToolkit.Tests.Time
             Assert.Equal(DateTime.Parse(expectedDtStr), actual);
         }
 
-        [Fact]
-        public void GetStartOfMonth_TestResults()
+        [Theory]
+        [InlineData("2020-01-31 23:59:59.999", "2020-01-01 0:00:00")]
+        [InlineData("2020-01-15", "2020-01-01 0:00:00")]
+        public void GetStartOfMonth_TestResults_UsingExtensionMethod(string inputDtStr, string expectedDtStr)
         {
-            DateTime input = DateTime.Parse("2020-01-01 0:00:00");
-            DateTime actual = input.StartOfMonth();
-            Assert.Equal(DateTime.Parse("2020-01-01 0:00:00"), actual);
+            DateTime actual = DateTime.Parse(inputDtStr).StartOfMonth();
+            DateTime expected = DateTime.Parse(expectedDtStr);
+            Assert.Equal(expected, actual);
         }
 
-        [Fact]
-        public void GetEndOfMonth_TestResults()
+        [Theory]
+        [InlineData("2020-01-01 0:00:00", "2020-01-31 23:59:59.999")]
+        [InlineData("2020-01-15", "2020-01-31 23:59:59.999")]
+        [InlineData("2022-02-15", "2022-02-29 23:59:59.999")]
+        [InlineData("2021-02-15", "2022-02-28 23:59:59.999")]
+        public void GetEndOfMonth_TestResults_UsingExtensionMethod(string inputDtStr, string expectedDtStr)
         {
-            DateTime input = DateTime.Parse("2020-01-01 0:00:00");
-            DateTime actual = input.EndOfMonth();
-            Assert.Equal(DateTime.Parse("2020-01-31 23:59:59.999"), actual);
+            DateTime actual = DateTime.Parse(inputDtStr).EndOfMonth();
+            DateTime expected = DateTime.Parse(expectedDtStr);
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/CoffeeToolkit.Tests/Time/DateTimeRounderTests.cs
+++ b/CoffeeToolkit.Tests/Time/DateTimeRounderTests.cs
@@ -70,8 +70,8 @@ namespace CoffeeToolkit.Tests.Time
         [Theory]
         [InlineData("2020-01-01 0:00:00", "2020-01-31 23:59:59.999")]
         [InlineData("2020-01-15", "2020-01-31 23:59:59.999")]
-        [InlineData("2022-02-15", "2022-02-29 23:59:59.999")]
-        [InlineData("2021-02-15", "2022-02-28 23:59:59.999")]
+        [InlineData("2024-02-15", "2024-02-29 23:59:59.999")]
+        [InlineData("2021-02-15", "2021-02-28 23:59:59.999")]
         public void GetEndOfMonth_TestResults_UsingExtensionMethod(string inputDtStr, string expectedDtStr)
         {
             DateTime actual = DateTime.Parse(inputDtStr).EndOfMonth();

--- a/CoffeeToolkit.Tests/Time/UnixTimeTests.cs
+++ b/CoffeeToolkit.Tests/Time/UnixTimeTests.cs
@@ -1,48 +1,25 @@
-﻿using CoffeeToolkit.Time;
-using System;
-using Xunit;
+﻿namespace CoffeeToolkit.Tests.Time;
 
-namespace CoffeeToolkit.Tests.Time
+public class UnixTimeTests
 {
-    public class UnixTimeTests
+    [Theory]
+    [InlineData("2020-01-01 0:00:00", 1577836800)]
+    [InlineData("2020-01-01 0:00:00.999", 1577836800)] // Expect floor
+    [InlineData("1969-01-01 0:00:00", -31536000)] // Expect negative
+    public void FromDateTimeToSeconds_WithLocalDateTimeOverride_ExpectUtcTimestamp(string dtStr, int expected)
     {
-        [Theory]
-        [InlineData("2020-01-01 0:00:00", 1577836800)]
-        [InlineData("2020-01-01 0:00:00.999", 1577836800)] // Expect floor
-        [InlineData("1969-01-01 0:00:00", -31536000)] // Expect negative
-        public void FromDateTime_TestResults(string dtStr, int expected)
-        {
-            DateTime input = DateTime.Parse(dtStr);
-            int actual = UnixTime.FromDateTime(input);
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory]
-        [InlineData("2040-01-01 0:00:00")] // Too high
-        [InlineData("1900-01-01 0:00:00")] //Too low
-        public void FromDateTime_OutOfRange_ExpectException(string dtStr)
-        {
-            DateTime input = DateTime.Parse(dtStr);
-            Assert.Throws<ArgumentOutOfRangeException>(() => UnixTime.FromDateTime(input));
-        }
-
-        [Theory]
-        [InlineData("2020-01-01 0:00:00", 1577836800)]
-        [InlineData("1969-01-01 0:00:00", -31536000)] // With negative
-        public void ToDateTime_TestResults(string dtStr, int input)
-        {
-            DateTime expected = DateTime.Parse(dtStr);
-            DateTime actual = UnixTime.ToDateTime(input);
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory]
-        [InlineData("2020-01-01 0:00:00", 1577836800)]
-        public void ToUnixTime_ExtensionMethod(string dtStr, int expected)
-        {
-            DateTime input = DateTime.Parse(dtStr);
-            int actual = input.ToUnixTime();
-            Assert.Equal(expected, actual);
-        }
+        DateTime input = DateTime.Parse(dtStr);
+        long actual = UnixTime.FromDateTimeToSeconds(input, true);
+        Assert.Equal(expected, actual);
+    }
+    
+    [Theory]
+    [InlineData("2020-01-01 0:00:00", 1577836800)]
+    [InlineData("1969-01-01 0:00:00", -31536000)] // With negative
+    public void ToDateTime_TestResults(string dtStr, int input)
+    {
+        DateTime expected = DateTime.Parse(dtStr);
+        DateTime actual = UnixTime.SecondsToDateTimeUtc(input);
+        Assert.Equal(expected, actual);
     }
 }

--- a/CoffeeToolkit.Tests/Usings.cs
+++ b/CoffeeToolkit.Tests/Usings.cs
@@ -1,0 +1,3 @@
+﻿global using System;
+global using Xunit;
+global using CoffeeToolkit.Time;

--- a/CoffeeToolkit.Time/DateTimeExtensions.cs
+++ b/CoffeeToolkit.Time/DateTimeExtensions.cs
@@ -3,12 +3,22 @@
     public static class DateTimeExtensions
     {
         /// <summary>
-        /// Converts value to Unix Time
+        /// Converts value to UTC Unix Time in seconds
         /// </summary>
         /// <param name="dt"></param>
+        /// <param name="castToUtc"></param>
         /// <returns></returns>
-        public static int ToUnixTime(this DateTime dt)
-            => UnixTime.FromDateTime(dt);
+        public static long ToUnixTimeSeconds(this DateTime dt, bool castToUtc = false)
+            => UnixTime.FromDateTimeToSeconds(dt, castToUtc);
+
+        /// <summary>
+        /// Converts value to UTC Unix Time in milliseconds
+        /// </summary>
+        /// <param name="dt"></param>
+        /// <param name="castToUtc">Set to true when the input DateTime is UTC but it's kind is not specified as UTC.</param>
+        /// <returns></returns>
+        public static long ToUnixTimeMilliseconds(this DateTime dt, bool castToUtc = false)
+            => UnixTime.FromDateTimeToMilliseconds(dt, castToUtc);
 
         /// <summary>
         /// Rounds up to the nearest increment by a given TimeSpan
@@ -46,12 +56,21 @@
             => DateTimeRounder.GetStartOfMonth(dt.Year, dt.Month, dt.Kind);
 
         /// <summary>
-        /// Get DateTime for the last milisecond of the month
+        /// Get DateTime for the last millisecond of the month
         /// </summary>
         /// <param name="dt"></param>
         /// <returns></returns>
         public static DateTime EndOfMonth(this DateTime dt)
             => DateTimeRounder.GetEndOfMonth(dt.Year, dt.Month, dt.Kind);
-        
+
+        /// <summary>
+        /// Converts DateTime into DateTimeOffset with the option to override the DateTimeKind
+        /// </summary>
+        /// <param name="dt">DateTime to parse</param>
+        /// <param name="overrideKind">Optionally override the DateTime kind</param>
+        /// <returns></returns>
+        public static DateTimeOffset ToDateTimeOffsetUtc(this DateTime dt, DateTimeKind? overrideKind)
+            => new DateTimeOffset(overrideKind.HasValue ?
+                DateTime.SpecifyKind(dt, overrideKind.Value) : dt);
     }
 }

--- a/CoffeeToolkit.Time/DateTimeRounder.cs
+++ b/CoffeeToolkit.Time/DateTimeRounder.cs
@@ -54,7 +54,7 @@ public static class DateTimeRounder
         => new DateTime(year, month, 1, 0,0,0, kind);
 
     /// <summary>
-    /// Get DateTime for the last milisecond of the month
+    /// Get DateTime for the last millisecond of the month
     /// </summary>
     /// <param name="year"></param>
     /// <param name="month"></param>

--- a/CoffeeToolkit.Time/UnixTime.cs
+++ b/CoffeeToolkit.Time/UnixTime.cs
@@ -2,28 +2,41 @@
 
 public static class UnixTime
 {
-    private static readonly DateTime unixStartTime = new(1970, 1, 1);
-
     /// <summary>
-    /// Converts DateTime to Unix time
-    /// </summary>
-    /// <param name="dt"></param>
-    /// <exception cref="ArgumentOutOfRangeException">aaa</exception>
-    /// <returns></returns>
-    public static int FromDateTime(DateTime dt)
-    {
-        int result = (int)dt.Subtract(unixStartTime).TotalSeconds;
-        if (result == int.MinValue)
-            throw new ArgumentOutOfRangeException(
-                nameof(dt), "Input DateTime was too high or low to convert to Unix time.");
-        else return result;
-    }
-
-    /// <summary>
-    /// Converts Unix time to DateTime
+    /// Converts Unix time in seconds to DateTime
     /// </summary>
     /// <param name="unixTime"></param>
     /// <returns></returns>
-    public static DateTime ToDateTime(int unixTime)
-        => unixStartTime.AddSeconds(unixTime);
+    public static DateTime SecondsToDateTimeUtc(long unixTime)
+        => DateTimeOffset.FromUnixTimeSeconds(unixTime).UtcDateTime;
+
+    /// <summary>
+    /// Converts Unix time in milliseconds to DateTime
+    /// </summary>
+    /// <param name="unixTime"></param>
+    /// <returns></returns>
+    public static DateTime MillisecondsToDateTimeUtc(long unixTime)
+        => DateTimeOffset.FromUnixTimeMilliseconds(unixTime).UtcDateTime;
+
+    /// <summary>
+    /// Converts value to UTC Unix Time in seconds
+    /// </summary>
+    /// <param name="dt"></param>
+    /// <param name="castToUtc"></param>
+    /// <returns></returns>
+    public static long FromDateTimeToSeconds(this DateTime dt, bool castToUtc = false)
+        => dt
+        .ToDateTimeOffsetUtc(castToUtc && dt.Kind != DateTimeKind.Utc ? DateTimeKind.Utc : null)
+        .ToUnixTimeSeconds();
+
+    /// <summary>
+    /// Converts value to UTC Unix Time in milliseconds
+    /// </summary>
+    /// <param name="dt"></param>
+    /// <param name="castToUtc">Set to true when the input DateTime is UTC but it's kind is not specified as UTC.</param>
+    /// <returns></returns>
+    public static long FromDateTimeToMilliseconds(this DateTime dt, bool castToUtc = false)
+        => dt
+        .ToDateTimeOffsetUtc(castToUtc && dt.Kind != DateTimeKind.Utc ? DateTimeKind.Utc : null)
+        .ToUnixTimeMilliseconds();
 }

--- a/CoffeeToolkit.Time/UnixTime.cs
+++ b/CoffeeToolkit.Time/UnixTime.cs
@@ -7,22 +7,22 @@ public static class UnixTime
     /// </summary>
     /// <param name="unixTime"></param>
     /// <returns></returns>
-    public static DateTime SecondsToDateTimeUtc(long unixTime)
-        => DateTimeOffset.FromUnixTimeSeconds(unixTime).UtcDateTime;
+    public static DateTime SecondsToDateTimeUtc(long unixTimeSeconds)
+        => DateTimeOffset.FromUnixTimeSeconds(unixTimeSeconds).UtcDateTime;
 
     /// <summary>
     /// Converts Unix time in milliseconds to DateTime
     /// </summary>
     /// <param name="unixTime"></param>
     /// <returns></returns>
-    public static DateTime MillisecondsToDateTimeUtc(long unixTime)
-        => DateTimeOffset.FromUnixTimeMilliseconds(unixTime).UtcDateTime;
+    public static DateTime MillisecondsToDateTimeUtc(long unixTimeMilliseconds)
+        => DateTimeOffset.FromUnixTimeMilliseconds(unixTimeMilliseconds).UtcDateTime;
 
     /// <summary>
     /// Converts value to UTC Unix Time in seconds
     /// </summary>
     /// <param name="dt"></param>
-    /// <param name="castToUtc"></param>
+    /// <param name="castToUtc">Assume literal time is UTC, even if DateTimeKind is not set to UTC</param>
     /// <returns></returns>
     public static long FromDateTimeToSeconds(this DateTime dt, bool castToUtc = false)
         => dt
@@ -33,7 +33,7 @@ public static class UnixTime
     /// Converts value to UTC Unix Time in milliseconds
     /// </summary>
     /// <param name="dt"></param>
-    /// <param name="castToUtc">Set to true when the input DateTime is UTC but it's kind is not specified as UTC.</param>
+    /// <param name="castToUtc">Assume literal time is UTC, even if DateTimeKind is not set to UTC</param>
     /// <returns></returns>
     public static long FromDateTimeToMilliseconds(this DateTime dt, bool castToUtc = false)
         => dt


### PR DESCRIPTION
- Scrap the UnixTime class with custom implementation
- Extension methods reworked to use .NET implementations
- Extension methods renamed to distinguish between seconds and miliseconds
- Methods always work with long instead of int
- Timestamps are expected to always be expressed in UTC, regardless of timezone
- DateTime can be cast as UTC to interpret the literal time (useful when working with API parsed data)
- Updated [docs](https://github.com/NotCoffee418/CoffeeToolkit/wiki/Time.UnixTime).

Other:
- [Improve tests for GetStartOfMonth & GetEndOfMonth](https://github.com/NotCoffee418/CoffeeToolkit/commit/f701b798369f1ad9d22eaa031a504276169ec2e7)